### PR TITLE
Add batch minting, optimize "mint" and "mintAndApprove" functions

### DIFF
--- a/contracts/erc-721/Collection.sol
+++ b/contracts/erc-721/Collection.sol
@@ -71,25 +71,29 @@ contract Collection is
     function mint(address recipient, string calldata tokenCID)
         external
         onlyOwner
-        returns (uint256 tokenId)
     {
-        tokenId = ++latestTokenId;
-        _safeMint(recipient, tokenId);
+        uint256 tokenId;
+        unchecked {
+            tokenId = ++latestTokenId;
+        }
+        _mint(recipient, tokenId);
         _tokenCIDs[tokenId] = tokenCID;
-        emit Mint(tokenId, owner);
+        emit Mint(tokenId, msg.sender);
     }
 
     function mintAndApprove(
         address recipient,
         string calldata tokenCID,
         address operator
-    ) external onlyOwner returns (uint256 tokenId) {
-        tokenId = ++latestTokenId;
-        _safeMint(recipient, tokenId);
+    ) external onlyOwner {
+        uint256 tokenId;
+        unchecked {
+            tokenId = ++latestTokenId;
+        }
         setApprovalForAll(operator, true);
+        _mint(recipient, tokenId);
         _tokenCIDs[tokenId] = tokenCID;
-        emit Mint(tokenId, owner);
-        return tokenId;
+        emit Mint(tokenId, msg.sender);
     }
 
     function tokenURI(uint256 tokenId)

--- a/contracts/erc-721/Collection.sol
+++ b/contracts/erc-721/Collection.sol
@@ -43,6 +43,12 @@ contract Collection is
      */
     event Mint(uint256 indexed tokenId, address artistId);
 
+    /**
+     * @notice Emitted when batch of NFTs is minted
+     * @param startTokenId The tokenId of the first minted NFT in the batch
+     * @param endTokenId The tokenId of the last minted NFT in the batch
+     * @param artistId The address of the creator
+     */
     event BatchMint(uint256 startTokenId, uint256 endTokenId, address artistId);
 
     modifier onlyOwner() {
@@ -93,7 +99,8 @@ contract Collection is
             startTokenId = currentTokenId + 1;
         }
 
-        for (uint256 i = 0; i < tokenCIDs.length; ) {
+        uint256 tokenCIDsLength = tokenCIDs.length;
+        for (uint256 i = 0; i < tokenCIDsLength; ) {
             unchecked {
                 ++currentTokenId;
             }

--- a/contracts/erc-721/Collection.sol
+++ b/contracts/erc-721/Collection.sol
@@ -43,6 +43,8 @@ contract Collection is
      */
     event Mint(uint256 indexed tokenId, address artistId);
 
+    event BatchMint(uint256 startTokenId, uint256 endTokenId, address artistId);
+
     modifier onlyOwner() {
         if (owner != msg.sender) revert CallerNotOwner();
         _;
@@ -79,6 +81,33 @@ contract Collection is
         _mint(recipient, tokenId);
         _tokenCIDs[tokenId] = tokenCID;
         emit Mint(tokenId, msg.sender);
+    }
+
+    function batchMint(address recipient, string[] calldata tokenCIDs)
+        external
+        onlyOwner
+    {
+        uint256 currentTokenId = latestTokenId;
+        uint256 startTokenId;
+        unchecked {
+            startTokenId = currentTokenId + 1;
+        }
+
+        for (uint256 i = 0; i < tokenCIDs.length; ) {
+            unchecked {
+                ++currentTokenId;
+            }
+
+            _mint(recipient, currentTokenId);
+            _tokenCIDs[currentTokenId] = tokenCIDs[i];
+
+            unchecked {
+                ++i;
+            }
+        }
+
+        latestTokenId = currentTokenId;
+        emit BatchMint(startTokenId, currentTokenId, msg.sender);
     }
 
     function mintAndApprove(


### PR DESCRIPTION
|  | before | after | diff |
|---|---|---|---|
| mint 1 NFT | 165539 ("mint" func) | 162433 ("mint" func) | -3106 |
| mint and approve 1 NFT | 190240 ("mintAndApprove" func) | 187229 ("mintAndApprove" func) | -3011 |
| mint 10 NFTs | 1347590 ("mint" func) | 1001330 ("batchMint" func) | −346260 |
| mint 20 NFTs | 2660980 ("mint" func) | 1932518 ("batchMint" func) | −728462 |

Pretpostavka je da owner kolekcije nikad nece izmintat 2^256 - 1 tokena inace bi doslo do overflowa.